### PR TITLE
Upgrade to .NET 4.8 and Fix TLS issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: msbuild ccx_testsuite.sln /t:ccx_testsuite /p:Platform="x86" /p:Configuration=Release
 
       - name: Prepare artifact upload
-        run: mkdir ./artifact; cp CCExtractorTester.exe ./artifact/CCExtractorTester.exe; cp testGenerations.dll ./artifact/testGenerations.dll; cp CommandLine.dll ./artifact/CommandLine.dll
+        run: mkdir ./artifact; cp CCExtractorTester.exe ./artifact/; cp testGenerations.dll ./artifact/; cp CommandLine.dll ./artifact/; cp CCExtractorTester.exe.config ./artifact/
         working-directory: CCExtractorTester\bin\Release\
 
       - name: Archive Release

--- a/CCExtractorTester/Comparers/ServerComparer.cs
+++ b/CCExtractorTester/Comparers/ServerComparer.cs
@@ -29,7 +29,7 @@ namespace CCExtractorTester.Comparers
 
         private byte[] UploadFiles(string address, IEnumerable<UploadFile> files, NameValueCollection values)
         {
-	    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             var request = WebRequest.Create(address);
             request.Method = "POST";
             var boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x", NumberFormatInfo.InvariantInfo);
@@ -133,7 +133,7 @@ namespace CCExtractorTester.Comparers
             else
             {
                 // Post equality status
-		ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
                 using (var wb = new WebClient())
                 {
                     wb.Headers.Add("user-agent", userAgent);
@@ -176,7 +176,7 @@ namespace CCExtractorTester.Comparers
         public void SendExitCodeAndRuntime(RunData rd, int testId)
         {
             // Post equality status
-	    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             using (var wb = new WebClient())
             {
                 var d = new NameValueCollection();

--- a/CCExtractorTester/app.config
+++ b/CCExtractorTester/app.config
@@ -1,15 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="ReportFolder" value="E:\CCExtractor repository\reports" />
-    <add key="SampleFolder" value="E:\CCExtractor repository\TestFiles" />
-    <add key="CorrectResultFolder" value="E:\CCExtractor repository\TestResults" />
-    <add key="CCExtractorLocation" value="C:\Program Files (x86)\CCExtractor\ccextractorwin.exe" />
+    <add key="ReportFolder" value="E:\CCExtractor repository\reports"/>
+    <add key="SampleFolder" value="E:\CCExtractor repository\TestFiles"/>
+    <add key="CorrectResultFolder" value="E:\CCExtractor repository\TestResults"/>
+    <add key="CCExtractorLocation" value="C:\Program Files (x86)\CCExtractor\ccextractorwin.exe"/>
     <!-- only necessary if you want to use a test with UDP -->
-    <add key="FFMpegLocation" value="C:\Program Files (x86)\WinFF\ffmpeg.exe" />
+    <add key="FFMpegLocation" value="C:\Program Files (x86)\WinFF\ffmpeg.exe"/>
     <!-- Comparer should be one of the next values: "Diff" (linux only), "Diffplex", "Diffplexreduced" (saves only the lines that are modified) -->
-    <add key="Comparer" value="Diffplex" />
-    <add key="UseThreading" value="false" />
-    <add key="BreakOnErrors" value="false" />
+    <add key="Comparer" value="Diffplex"/>
+    <add key="UseThreading" value="false"/>
+    <add key="BreakOnErrors" value="false"/>
   </appSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/CCExtractorTester/ccx_testsuite.csproj
+++ b/CCExtractorTester/ccx_testsuite.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -25,6 +25,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,6 +39,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <ConsolePause>false</ConsolePause>
     <Commandlineparameters>-t "E:\CCExtractor repository\TestFiles\TestAll.xml"</Commandlineparameters>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>full</DebugType>
@@ -46,6 +49,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <ConsolePause>false</ConsolePause>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ CCExtractortester.exe -m Server -u http://my.server/report.php -e C:\Samples\Tes
 
 * Mono 2.10 or newer (A tutorial can be found [here](http://www.nat.li/linux/how-to-install-mono-2-11-2-on-debian-squeeze))
 
+The following script can be used to run the testsuite on linux, by passing the required arguments to it:
+```
+#!/bin/bash
+exec mono CCExtractorTester.exe "$@"
+```
+
 ### Common
 
 * CommandLineParser NuGet package ([GitHub](https://github.com/gsscoder/commandline), [nuget](https://www.nuget.org/packages/CommandLineParser))

--- a/conversionTools/App.config
+++ b/conversionTools/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/conversionTools/conversionTools.csproj
+++ b/conversionTools/conversionTools.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>conversionTools</RootNamespace>
     <AssemblyName>conversionTools</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PublishUrl>publish\</PublishUrl>
@@ -27,6 +27,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/testGenerations/Properties/Resources.Designer.cs
+++ b/testGenerations/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace testGenerations.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -62,20 +62,18 @@ namespace testGenerations.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to &lt;xs:schema xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;&gt;
-        ///  &lt;xs:element name=&quot;multitest&quot;&gt;
-        ///    &lt;xs:complexType&gt;
-        ///      &lt;xs:sequence&gt;
-        ///        &lt;xs:element name=&quot;testfile&quot; maxOccurs=&quot;unbounded&quot; minOccurs=&quot;1&quot;&gt;
-        ///          &lt;xs:complexType&gt;
+        ///    &lt;xs:element name=&quot;multitest&quot;&gt;
+        ///        &lt;xs:complexType&gt;
         ///            &lt;xs:sequence&gt;
-        ///              &lt;xs:element type=&quot;xs:string&quot; name=&quot;location&quot;/&gt;
+        ///                &lt;xs:element name=&quot;testfile&quot; maxOccurs=&quot;unbounded&quot; minOccurs=&quot;1&quot;&gt;
+        ///                    &lt;xs:complexType&gt;
+        ///                        &lt;xs:sequence&gt;
+        ///                            &lt;xs:element type=&quot;xs:string&quot; name=&quot;location&quot;/&gt;
+        ///                        &lt;/xs:sequence&gt;
+        ///                    &lt;/xs:complexType&gt;
+        ///                &lt;/xs:element&gt;
         ///            &lt;/xs:sequence&gt;
-        ///          &lt;/xs:complexType&gt;
-        ///        &lt;/xs:element&gt;
-        ///      &lt;/xs:sequence&gt;
-        ///    &lt;/xs:complexType&gt;
-        ///  &lt;/xs:element&gt;
-        ///&lt;/xs:schema&gt;.
+        ///       [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string multitest {
             get {
@@ -85,16 +83,15 @@ namespace testGenerations.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to &lt;xs:schema attributeFormDefault=&quot;unqualified&quot; elementFormDefault=&quot;qualified&quot; xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;&gt;
-        ///  &lt;xs:element name=&quot;tests&quot;&gt;
-        ///    &lt;xs:complexType&gt;
-        ///      &lt;xs:sequence&gt;
-        ///        &lt;xs:element name=&quot;test&quot; maxOccurs=&quot;unbounded&quot; minOccurs=&quot;1&quot;&gt;
-        ///          &lt;xs:complexType&gt;
+        ///    &lt;xs:element name=&quot;tests&quot;&gt;
+        ///        &lt;xs:complexType&gt;
         ///            &lt;xs:sequence&gt;
-        ///              &lt;xs:element type=&quot;xs:string&quot; name=&quot;sample&quot;/&gt;
-        ///              &lt;xs:element type=&quot;xs:string&quot; name=&quot;cmd&quot;/&gt;
-        ///              &lt;xs:element type=&quot;xs:string&quot; name=&quot;result&quot;/&gt;
-        ///            &lt;/xs:sequence [rest of string was truncated]&quot;;.
+        ///                &lt;xs:element name=&quot;test&quot; maxOccurs=&quot;unbounded&quot; minOccurs=&quot;1&quot;&gt;
+        ///                    &lt;xs:complexType&gt;
+        ///                        &lt;xs:sequence&gt;
+        ///                            &lt;xs:element type=&quot;xs:string&quot; name=&quot;sample&quot;/&gt;
+        ///                            &lt;xs:element type=&quot;xs:string&quot; name=&quot;cmd&quot;/&gt;
+        ///               [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string tests {
             get {
@@ -105,16 +102,14 @@ namespace testGenerations.Properties {
         /// <summary>
         ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
         ///&lt;xs:schema attributeFormDefault=&quot;unqualified&quot; elementFormDefault=&quot;qualified&quot; xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;&gt;
-        ///  &lt;xs:element name=&quot;tests&quot;&gt;
-        ///    &lt;xs:complexType&gt;
-        ///      &lt;xs:sequence&gt;
-        ///        &lt;xs:element name=&quot;entry&quot; maxOccurs=&quot;unbounded&quot; minOccurs=&quot;1&quot;&gt;
-        ///          &lt;xs:complexType&gt;
+        ///    &lt;xs:element name=&quot;tests&quot;&gt;
+        ///        &lt;xs:complexType&gt;
         ///            &lt;xs:sequence&gt;
-        ///              &lt;xs:element type=&quot;xs:string&quot; name=&quot;command&quot;/&gt;
-        ///              &lt;xs:element name=&quot;input&quot;&gt;
-        ///                &lt;xs:complexType&gt;
-        ///                  &lt;xs:simp [rest of string was truncated]&quot;;.
+        ///                &lt;xs:element name=&quot;entry&quot; maxOccurs=&quot;unbounded&quot; minOccurs=&quot;1&quot;&gt;
+        ///                    &lt;xs:complexType&gt;
+        ///                        &lt;xs:sequence&gt;
+        ///                            &lt;xs:element type=&quot;xs:string&quot; name=&quot;command&quot;/&gt;
+        ///                            &lt;xs:element nam [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string testsuite {
             get {

--- a/testGenerations/testGenerations.csproj
+++ b/testGenerations/testGenerations.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>testGenerations</RootNamespace>
     <AssemblyName>testGenerations</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Since .NET 4.0 is no longer supported, it would be better if we upgrade to higher version.

Also please include CCExtractor.exe.config in the release and the following script for running tester on linux:

```
#!/bin/bash
exec mono CCExtractorTester.exe "$@"
```